### PR TITLE
feat: set internal config options on initialization

### DIFF
--- a/include/Command.h
+++ b/include/Command.h
@@ -6,10 +6,7 @@
 #include "types.h"
 #include "Update.h"
 #include "Report.h"
-
-#ifndef RESET_DELAY_MS
-#define RESET_DELAY_MS 4000
-#endif
+#include "Store.h"
 
 namespace ESPAdmin
 {

--- a/include/ESPAdmin.h
+++ b/include/ESPAdmin.h
@@ -6,10 +6,13 @@
 #include "Store.h"
 #include "Command.h"
 #include "MQTT.h"
+#include "types.h"
+
+#define DEFAULT_INT(x, y) (x == 0 ? y : x)
 
 namespace ESPAdmin
 {
-    void begin(const char *httpHost, const char *deviceId, const char *apiKey, const char *httpCert, const char *mqttCert);
+    void begin(InitOptions options);
 }
 
 #endif

--- a/include/HTTP.h
+++ b/include/HTTP.h
@@ -5,14 +5,6 @@
 #include "Store.h"
 #include <esp_http_client.h>
 
-#ifndef HTTP_MAX_RESPONSE_SIZE
-#define HTTP_MAX_RESPONSE_SIZE 300
-#endif
-
-#ifndef HTTP_TIMEOUT_MS
-#define HTTP_TIMEOUT_MS 8000
-#endif
-
 namespace ESPAdmin
 {
     class Logger;
@@ -21,7 +13,7 @@ namespace ESPAdmin
     {
     public:
         static String get(const String &path);
-        static String post(const String &path, const String &content,const String &contentType);
+        static String post(const String &path, const String &content, const String &contentType);
 
     private:
         static Logger _logger;

--- a/include/Logger.h
+++ b/include/Logger.h
@@ -5,10 +5,6 @@
 #include "Store.h"
 #include "MQTT.h"
 
-#ifndef MAX_LOG_MESSAGE_SIZE
-#define MAX_LOG_MESSAGE_SIZE 100
-#endif
-
 // ANSI escape codes for text color
 #define ANSI_COLOR_RED "\x1b[41m"
 #define ANSI_COLOR_GREEN "\x1b[42m"

--- a/include/MQTT.h
+++ b/include/MQTT.h
@@ -8,26 +8,6 @@
 #include "Command.h"
 #include "Report.h"
 
-#ifndef MQTT_TASK_STACK_SIZE
-#define MQTT_TASK_STACK_SIZE 6896 // StackHighWaterMark = 4848 bytes
-#endif
-
-#ifndef MQTT_KEEP_ALIVE_SEC
-#define MQTT_KEEP_ALIVE_SEC 30
-#endif
-
-#ifndef MQTT_NETWORK_TIMEOUT_MS
-#define MQTT_NETWORK_TIMEOUT_MS 8000
-#endif
-
-#ifndef MQTT_RECONNECT_TIMEOUT_MS
-#define MQTT_RECONNECT_TIMEOUT_MS 10000
-#endif
-
-#ifndef MQTT_TASK_PRIORITY
-#define MQTT_TASK_PRIORITY 5
-#endif
-
 namespace ESPAdmin
 {
     class Logger;

--- a/include/OTA.h
+++ b/include/OTA.h
@@ -1,18 +1,6 @@
 #ifndef H_ESP_ADMIN_OTA
 #define H_ESP_ADMIN_OTA
 
-#ifndef HTTP_TIMEOUT_MS
-#define HTTP_TIMEOUT_MS 8000
-#endif
-
-#ifndef OTA_TASK_STACK_SIZE
-#define OTA_TASK_STACK_SIZE 4408 // StackHighWaterMark = 3384 bytes
-#endif
-
-#ifndef OTA_TASK_PRIORITY
-#define OTA_TASK_PRIORITY 5
-#endif
-
 #include <Arduino.h>
 #include <esp_http_client.h>
 #include <esp_https_ota.h>

--- a/include/Store.h
+++ b/include/Store.h
@@ -6,6 +6,7 @@
 #include <Arduino.h>
 #include "HTTP.h"
 #include "Logger.h"
+#include "Store.h"
 
 namespace ESPAdmin
 {
@@ -14,7 +15,7 @@ namespace ESPAdmin
     class Store
     {
     public:
-        static void begin(const char *httpHost, const char *deviceId, const char *apiKey, const char *httpCert, const char *mqttCert);
+        static void begin(const InitOptions options);
         static void set(StoreKey key, const char *value);
         static String get(StoreKey key);
 
@@ -25,11 +26,7 @@ namespace ESPAdmin
         static bool logRemoteEnabled;
 
         // constants
-        static const char *deviceId;
-        static const char *httpHost;
-        static const char *apiKey;
-        static const char *httpCert;
-        static const char *mqttCert;
+        static InitOptions options;
 
     private:
         static NVS _NVS;

--- a/include/Update.h
+++ b/include/Update.h
@@ -8,10 +8,6 @@
 #include "Logger.h"
 #include "Report.h"
 
-#ifndef RESET_DELAY_MS 
-#define RESET_DELAY_MS 4000
-#endif
-
 namespace ESPAdmin
 {
     class Logger;

--- a/include/types.h
+++ b/include/types.h
@@ -46,6 +46,26 @@ namespace ESPAdmin
         String body;
     };
 
+    struct InitOptions
+    {
+        const char *httpHost;
+        const char *deviceId;
+        const char *apiKey;
+        const char *httpCert;
+        const char *mqttCert;
+        uint16_t resetDelayMs;
+        uint16_t httpMaxResponseSize;
+        uint16_t httpTimeoutMs;
+        uint16_t logMaxMessageSize;
+        uint8_t mqttTaskPriority;
+        uint16_t mqttTaskStackSize;
+        uint8_t mqttKeepAliveSec;
+        uint16_t mqttNetworkTimeoutMs;
+        uint16_t mqttReconnectTimeoutMs;
+        uint8_t otaTaskPriority;
+        uint16_t otaTaskStackSize;
+    };
+
     using OnCustomCommand = void (*)(String);
     using OnConfigCommand = void (*)(String);
 }

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -74,7 +74,7 @@ namespace ESPAdmin
         Report::sendStatus("disconnected");
 
         // Wait for MQTT publish to finish
-        delay(RESET_DELAY_MS);
+        delay(Store::options.resetDelayMs);
 
         esp_restart();
     }

--- a/src/ESPAdmin.cpp
+++ b/src/ESPAdmin.cpp
@@ -2,9 +2,21 @@
 
 namespace ESPAdmin
 {
-  void begin(const char *httpHost, const char *deviceId, const char *apiKey, const char *httpCert, const char *mqttCert)
+  void begin(InitOptions options)
   {
-    Store::begin(httpHost, deviceId, apiKey, httpCert, mqttCert);
+    options.resetDelayMs = DEFAULT_INT(options.resetDelayMs, 7000);
+    options.httpMaxResponseSize = DEFAULT_INT(options.httpMaxResponseSize, 300);
+    options.httpTimeoutMs = DEFAULT_INT(options.httpTimeoutMs, 8000);
+    options.logMaxMessageSize = DEFAULT_INT(options.logMaxMessageSize, 100);
+    options.mqttTaskPriority = DEFAULT_INT(options.mqttTaskPriority, 5);
+    options.mqttTaskStackSize = DEFAULT_INT(options.mqttTaskStackSize, 6896); // StackHighWaterMark = 4848 bytes
+    options.mqttKeepAliveSec = DEFAULT_INT(options.mqttKeepAliveSec, 30);
+    options.mqttNetworkTimeoutMs = DEFAULT_INT(options.mqttNetworkTimeoutMs, 8000);
+    options.mqttReconnectTimeoutMs = DEFAULT_INT(options.mqttReconnectTimeoutMs, 10000);
+    options.otaTaskPriority = DEFAULT_INT(options.otaTaskPriority, 5);
+    options.otaTaskStackSize = DEFAULT_INT(options.otaTaskStackSize, 4408); // StackHighWaterMark = 3384 bytes
+
+    Store::begin(options);
 
     MQTT::connect();
   }

--- a/src/HTTP.cpp
+++ b/src/HTTP.cpp
@@ -6,22 +6,22 @@ namespace ESPAdmin
 
     String HTTP::get(const String &path)
     {
-        char response[HTTP_MAX_RESPONSE_SIZE] = "";
+        char response[Store::options.httpMaxResponseSize] = "";
 
-        String fullPath = "/api/device/" + String(Store::deviceId) + path;
+        String fullPath = "/api/device/" + String(Store::options.deviceId) + path;
 
         esp_http_client_config_t config = {
-            .host = Store::httpHost,
+            .host = Store::options.httpHost,
             .path = fullPath.c_str(),
-            .cert_pem = Store::httpCert,
+            .cert_pem = Store::options.httpCert,
             .method = HTTP_METHOD_GET,
-            .timeout_ms = HTTP_TIMEOUT_MS,
+            .timeout_ms = Store::options.httpTimeoutMs,
             .transport_type = HTTP_TRANSPORT_OVER_SSL,
         };
 
         esp_http_client_handle_t client = esp_http_client_init(&config);
 
-        esp_http_client_set_header(client, "Api-Key", Store::apiKey);
+        esp_http_client_set_header(client, "Api-Key", Store::options.apiKey);
 
         esp_err_t err = esp_http_client_open(client, 0);
 
@@ -43,7 +43,7 @@ namespace ESPAdmin
                 }
                 else
                 {
-                    esp_http_client_read_response(client, response, HTTP_MAX_RESPONSE_SIZE);
+                    esp_http_client_read_response(client, response, Store::options.httpMaxResponseSize);
                 }
             }
 
@@ -61,22 +61,22 @@ namespace ESPAdmin
 
     String HTTP::post(const String &path, const String &content, const String &contentType)
     {
-        char response[HTTP_MAX_RESPONSE_SIZE] = "";
+        char response[Store::options.httpMaxResponseSize] = "";
 
-        String fullPath = "/api/device/" + String(Store::deviceId) + path;
+        String fullPath = "/api/device/" + String(Store::options.deviceId) + path;
 
         esp_http_client_config_t config = {
-            .host = Store::httpHost,
+            .host = Store::options.httpHost,
             .path = fullPath.c_str(),
-            .cert_pem = Store::httpCert,
+            .cert_pem = Store::options.httpCert,
             .method = HTTP_METHOD_POST,
-            .timeout_ms = HTTP_TIMEOUT_MS,
+            .timeout_ms = Store::options.httpTimeoutMs,
             .transport_type = HTTP_TRANSPORT_OVER_SSL,
         };
 
         esp_http_client_handle_t client = esp_http_client_init(&config);
 
-        esp_http_client_set_header(client, "Api-Key", Store::apiKey);
+        esp_http_client_set_header(client, "Api-Key", Store::options.apiKey);
 
         esp_http_client_set_header(client, "Content-Type", contentType.c_str());
 
@@ -108,7 +108,7 @@ namespace ESPAdmin
                     }
                     else
                     {
-                        esp_http_client_read_response(client, response, HTTP_MAX_RESPONSE_SIZE);
+                        esp_http_client_read_response(client, response, Store::options.httpMaxResponseSize);
                     }
                 }
             }

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -11,7 +11,7 @@ namespace ESPAdmin
         va_list args;
         va_start(args, format);
 
-        char buffer[MAX_LOG_MESSAGE_SIZE];
+        char buffer[Store::options.logMaxMessageSize];
         vsnprintf(buffer, sizeof(buffer), format, args);
 
         va_end(args);
@@ -23,7 +23,7 @@ namespace ESPAdmin
         va_list args;
         va_start(args, format);
 
-        char buffer[MAX_LOG_MESSAGE_SIZE];
+        char buffer[Store::options.logMaxMessageSize];
         vsnprintf(buffer, sizeof(buffer), format, args);
 
         va_end(args);
@@ -35,7 +35,7 @@ namespace ESPAdmin
         va_list args;
         va_start(args, format);
 
-        char buffer[MAX_LOG_MESSAGE_SIZE];
+        char buffer[Store::options.logMaxMessageSize];
         vsnprintf(buffer, sizeof(buffer), format, args);
 
         va_end(args);
@@ -47,7 +47,7 @@ namespace ESPAdmin
         va_list args;
         va_start(args, format);
 
-        char buffer[MAX_LOG_MESSAGE_SIZE];
+        char buffer[Store::options.logMaxMessageSize];
         vsnprintf(buffer, sizeof(buffer), format, args);
 
         va_end(args);

--- a/src/MQTT.cpp
+++ b/src/MQTT.cpp
@@ -15,7 +15,7 @@ namespace ESPAdmin
 
         const char lwtMessage[] = R"({"status":"disconnected"})";
 
-        String lwtTopic = "device/" + String(Store::deviceId) + "/report/status";
+        String lwtTopic = "device/" + String(Store::options.deviceId) + "/report/status";
 
         String uri = uriTCP.length() > 3 ? uriTCP : uriWS;
 
@@ -23,19 +23,19 @@ namespace ESPAdmin
 
         esp_mqtt_client_config_t config = {
             .uri = uri.c_str(),
-            .client_id = Store::deviceId,
+            .client_id = Store::options.deviceId,
             .username = username.c_str(),
             .password = password.c_str(),
             .lwt_topic = lwtTopic.c_str(),
             .lwt_msg = lwtMessage,
             .lwt_qos = 1,
             .lwt_retain = true,
-            .keepalive = MQTT_KEEP_ALIVE_SEC,
-            .task_prio = MQTT_TASK_PRIORITY,
-            .task_stack = MQTT_TASK_STACK_SIZE,
-            .cert_pem = Store::mqttCert,
-            .reconnect_timeout_ms = MQTT_RECONNECT_TIMEOUT_MS,
-            .network_timeout_ms = MQTT_NETWORK_TIMEOUT_MS,
+            .keepalive = Store::options.mqttKeepAliveSec,
+            .task_prio = Store::options.mqttTaskPriority,
+            .task_stack = Store::options.mqttTaskStackSize,
+            .cert_pem = Store::options.mqttCert,
+            .reconnect_timeout_ms = Store::options.mqttReconnectTimeoutMs,
+            .network_timeout_ms = Store::options.mqttNetworkTimeoutMs,
         };
 
         _client = esp_mqtt_client_init(&config);
@@ -105,7 +105,7 @@ namespace ESPAdmin
     {
         if (Store::mqttConnected)
         {
-            String fullTopic = "device/" + String(Store::deviceId) + topic;
+            String fullTopic = "device/" + String(Store::options.deviceId) + topic;
             esp_mqtt_client_publish(_client, fullTopic.c_str(), message.c_str(), message.length(), qos, retain);
         }
     }
@@ -114,7 +114,7 @@ namespace ESPAdmin
     {
         if (Store::mqttConnected)
         {
-            String fullTopic = "device/" + String(Store::deviceId) + topic;
+            String fullTopic = "device/" + String(Store::options.deviceId) + topic;
             esp_mqtt_client_publish(_client, fullTopic.c_str(), message, len, qos, retain);
         }
     }
@@ -133,7 +133,7 @@ namespace ESPAdmin
 
         _logger.info("connected");
 
-        subscribe("device/" + String(Store::deviceId) + "/command/+", 1);
+        subscribe("device/" + String(Store::options.deviceId) + "/command/+", 1);
 
         Report::sendStatus("connected");
     }

--- a/src/OTA.cpp
+++ b/src/OTA.cpp
@@ -8,15 +8,15 @@ namespace ESPAdmin
     void OTA::start(const String &downloadURL)
     {
         _downloadURL = downloadURL;
-        xTaskCreatePinnedToCore(task, "ota_start", OTA_TASK_STACK_SIZE, nullptr, OTA_TASK_PRIORITY, nullptr, 1);
+        xTaskCreatePinnedToCore(task, "ota_start", Store::options.otaTaskStackSize, nullptr, Store::options.otaTaskPriority, nullptr, 1);
     }
 
     void OTA::task(void *)
     {
         esp_http_client_config_t config = {
             .url = _downloadURL.c_str(),
-            .cert_pem = Store::httpCert,
-            .timeout_ms = HTTP_TIMEOUT_MS,
+            .cert_pem = Store::options.httpCert,
+            .timeout_ms = Store::options.httpTimeoutMs,
         };
 
         Update::onChange(UPDATE_STARTED);

--- a/src/Store.cpp
+++ b/src/Store.cpp
@@ -12,21 +12,13 @@ namespace ESPAdmin
     bool Store::logSerialEnabled = true;
     bool Store::updateRunning = false;
 
-    const char *Store::deviceId;
-    const char *Store::httpHost;
-    const char *Store::apiKey;
-    const char *Store::httpCert;
-    const char *Store::mqttCert;
+    InitOptions Store::options;
 
-    void Store::begin(const char *httpHost, const char *deviceId, const char *apiKey, const char *httpCert, const char *mqttCert)
+    void Store::begin(const InitOptions options)
     {
         _NVS.begin(_namespace);
 
-        Store::httpHost = httpHost;
-        Store::deviceId = deviceId;
-        Store::apiKey = apiKey;
-        Store::httpCert = httpCert;
-        Store::mqttCert = mqttCert;
+        Store::options = options;
 
         _getSettings();
     }

--- a/src/Update.cpp
+++ b/src/Update.cpp
@@ -23,7 +23,7 @@ namespace ESPAdmin
         else
         {
             _logger.info("update to version %s", _message.version.c_str());
-            String downloadURL = "https://" + String(Store::httpHost) + message.downloadPath;
+            String downloadURL = "https://" + String(Store::options.httpHost) + message.downloadPath;
             OTA::start(downloadURL);
         }
     }
@@ -57,7 +57,7 @@ namespace ESPAdmin
         Report::sendStatus("disconnected");
 
         // Wait for MQTT publish to finish
-        delay(RESET_DELAY_MS);
+        delay(Store::options.resetDelayMs);
 
         esp_restart();
     }


### PR DESCRIPTION
This PR permits the setup of internal config options on initialization with `ESPAdmin::begin` which its signature is changed as a result.

```diff
- void begin(const char *httpHost, const char *deviceId, const char *apiKey, const char *httpCert, const char *mqttCert)
+ void begin(InitOptions options);
```
```cpp
   struct InitOptions
    {
        const char *httpHost;
        const char *deviceId;
        const char *apiKey;
        const char *httpCert;
        const char *mqttCert;
        uint16_t resetDelayMs;
        uint16_t httpMaxResponseSize;
        uint16_t httpTimeoutMs;
        uint16_t logMaxMessageSize;
        uint8_t mqttTaskPriority;
        uint16_t mqttTaskStackSize;
        uint8_t mqttKeepAliveSec;
        uint16_t mqttNetworkTimeoutMs;
        uint16_t mqttReconnectTimeoutMs;
        uint8_t otaTaskPriority;
        uint16_t otaTaskStackSize;
    };
```